### PR TITLE
Support the use of files paths as well as sha

### DIFF
--- a/src/githubcommitembed.js
+++ b/src/githubcommitembed.js
@@ -28,6 +28,8 @@
         this.fileSHA = options.fileSHA;
         this.username = options.username;
         this.reponame = options.reponame;
+        this.filePath = options.filePath;
+        this.ref = options.ref;
         return this;
     };
     
@@ -39,6 +41,8 @@
         username: undefined,
         reponame: undefined,
         content: undefined,
+        filePath: undefined,
+        ref: "master",
         
         /**
          *    GitHubCommit.fetch(optional_callbackfn);
@@ -54,7 +58,16 @@
             }
             
             /* String concatenation is ugly. */
-            var ghurl = ['https://api.github.com/repos/',this.username,'/',this.reponame,'/git/blobs/',this.fileSHA].join('');
+            var ghurl = '';
+            
+            if(this.fileSHA === undefined){
+               ghurl = ['https://api.github.com/repos/',this.username,'/',this.reponame,'/contents/',this.filePath,'?ref=', this.ref].join('');
+
+            }
+            else{
+               ghurl = ['https://api.github.com/repos/',this.username,'/',this.reponame,'/git/blobs/',this.fileSHA,'?ref=', this.ref].join('');
+            }
+       console.log(ghurl);
             GitHubCommit.util.jsonp(ghurl, this._parseSHAData, this);
             return this;
         },


### PR DESCRIPTION
I have updated the code so a user can specify a github content path and ref. For example:

``` HTML
<html>
<head>
<script src="http://code.jquery.com/jquery-1.9.0.min.js" type="text/javascript"></script>
<script type="text/javascript" src="git.js" >
</script>

</head>
<body>
<pre class="github cs" sha="02734cd5b1cc857b4a43760cd958d6a07a42307a">

</pre>

<pre class="github cs" file="docs/concepts/example-fluent-1.cs" ref="gh-pages">

</pre>


<script type="text/javascript">
(function($) {
    $(function () {

        $("pre.github").each(function () {

            var $pre = $(this);
            $pre.addClass("prettyprint");

            var sha = $pre.attr("sha");
            var path = $pre.attr("file");
console.log(path);
            var ref = $pre.attr("ref");
            var commit = new GitHubCommit({
                username: "mikeedwards83",
                reponame: "Glass.Mapper",
                fileSHA: sha,
        filePath: path,
                ref: ref


            });

            commit.fetch(function(content) {
                $pre.html(content);
                prettyPrint();
            });
        });

    });
})(jQuery);
</script>
</body>
</html>
```
